### PR TITLE
Added check for HTTP_ORIGIN index (fix #1)

### DIFF
--- a/src/Cors.php
+++ b/src/Cors.php
@@ -68,7 +68,7 @@ class Cors
 		if (static::isOriginAllowed($origin)) {
 			Headers::accessControl(
 				'Allow-Origin',
-				$_SERVER['HTTP_ORIGIN']
+				$_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_REFERER'] ?? $_SERVER['REMOTE_ADDR']
 			);
 		}
 
@@ -126,8 +126,7 @@ class Cors
 
 	protected static function isOriginAllowed($allowedOrigin)
 	{
-		if(isset($_SERVER['HTTP_ORIGIN']) === false){ return false; }
-		$origin = $_SERVER['HTTP_ORIGIN'];
+		$origin = $_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_REFERER'] ?? $_SERVER['REMOTE_ADDR'];
 
 		if (is_array($allowedOrigin)) {
 			for ($i = 0; $i < count($allowedOrigin); $i++) {

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -68,7 +68,7 @@ class Cors
 		if (static::isOriginAllowed($origin)) {
 			Headers::accessControl(
 				'Allow-Origin',
-				$_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_REFERER'] ?? $_SERVER['REMOTE_ADDR']
+				$_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_HOST']
 			);
 		}
 
@@ -126,8 +126,8 @@ class Cors
 
 	protected static function isOriginAllowed($allowedOrigin)
 	{
-		$origin = $_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_REFERER'] ?? $_SERVER['REMOTE_ADDR'];
-
+		$origin = $_SERVER['HTTP_ORIGIN'] ?? $_SERVER['HTTP_HOST'];
+		
 		if (is_array($allowedOrigin)) {
 			for ($i = 0; $i < count($allowedOrigin); $i++) {
 				if (static::isOriginAllowed($allowedOrigin[$i])) {

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -126,6 +126,7 @@ class Cors
 
 	protected static function isOriginAllowed($allowedOrigin)
 	{
+		if(isset($_SERVER['HTTP_ORIGIN']) === false){ return false; }
 		$origin = $_SERVER['HTTP_ORIGIN'];
 
 		if (is_array($allowedOrigin)) {


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

<!--
	Describe your changes in detail. In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
Added an if statement to the top of function isOriginAllowed to check if the HTTP_ORIGIN index was set in $_SERVER and return false if it is not found

This change prevents a notice exception from being thrown when $_SERVER['HTTP_ORIGIN'] does not exist and allows a user to view the resource

This is not a breaking change because if $_SERVER['HTTP_ORIGIN'] is set, it would continue the rest of the flow inside function isOriginAllowed

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->
[#1 ErrorException thrown with message "Undefined index: HTTP_ORIGIN"](https://github.com/leafsphp/cors/issues/1)
After creating a default leaf mvc project, then attempting to view the project the user receives a notice exception.
